### PR TITLE
added unity editor definitions on missing helper method calls

### DIFF
--- a/Runtime/Scripts/MusicPlayableBehaviour.cs
+++ b/Runtime/Scripts/MusicPlayableBehaviour.cs
@@ -208,11 +208,12 @@ namespace JSAM
                         helperSource.clip = Audio.Files[0];
                         UpdateTime(playable);
                     }
-
+#if UNITY_EDITOR
                     if (!helperSource.isPlaying)
                     {
                         Helper.PlayDebug(Audio);
                     }
+#endif
                 }
             }
             Helper.AudioSource.volume = Volume;

--- a/Runtime/Scripts/SoundPlayableBehaviour.cs
+++ b/Runtime/Scripts/SoundPlayableBehaviour.cs
@@ -208,11 +208,12 @@ namespace JSAM
                         helperSource.clip = Audio.Files[0];
                         helperSource.time = Mathf.Min((float)playable.GetTime(), helperSource.clip.length - AudioManagerInternal.EPSILON);
                     }
-
+#if UNITY_EDITOR
                     if (!helperSource.isPlaying)
                     {
                         Helper.PlayDebug(Audio);
                     }
+#endif
                 }
             }
             Helper.AudioSource.volume = Volume;


### PR DESCRIPTION
I was getting a build error due to forgotten UNITY_EDITOR definitions. I fixed it.