### PR TITLE
Cannot LoadAudioLibrary when AssemblyReferences used

### DIFF
--- a/Runtime/Scripts/AudioManagerInternal.cs
+++ b/Runtime/Scripts/AudioManagerInternal.cs
@@ -841,22 +841,22 @@ namespace JSAM
             var newLib = new LoadedLibrary { Library = l, Users = 1 };
 
             List<string> enums = new List<string>();
-            var soundType = l.soundEnumGenerated;
+            var soundTypeName = l.soundEnumGenerated;
 
             if (!l.soundNamespaceGenerated.IsNullEmptyOrWhiteSpace())
             {
-                soundType = l.soundNamespaceGenerated + "." + soundType;
+                soundTypeName = l.soundNamespaceGenerated + "." + soundTypeName;
             }
-            var assembly = soundType + ", Assembly-CSharp";
 
-            Type enumType = Type.GetType(assembly);
+            Type enumType = FindEnumType(soundTypeName);
+
             enums.AddRange(Enum.GetNames(enumType));
 
             newLib.SoundKeys = new long[enums.Count];
             for (int i = 0; i < l.Sounds.Count; i++)
             {
                 l.Sounds[i].Initialize();
-                var soundName = soundType + "." + enums[i];
+                var soundName = soundTypeName + "." + enums[i];
                 long key = ComputeEnumHash(enumType, i);
                 newLib.SoundKeys[i] = key;
                 audioFileLookup.Add(soundName, l.Sounds[i]);
@@ -864,21 +864,21 @@ namespace JSAM
             }
 
             enums.Clear();
-            var musicType = l.musicEnumGenerated;
+            var musicTypeName = l.musicEnumGenerated;
 
             if (!l.musicNamespaceGenerated.IsNullEmptyOrWhiteSpace())
             {
-                musicType = l.musicNamespaceGenerated + "." + musicType;
+                musicTypeName = l.musicNamespaceGenerated + "." + musicTypeName;
             }
-            assembly = musicType + ", Assembly-CSharp";
-
-            enumType = Type.GetType(assembly);
+            
+            enumType = FindEnumType(musicTypeName);
+            
             enums.AddRange(Enum.GetNames(enumType));
 
             newLib.MusicKeys = new long[enums.Count];
             for (int i = 0; i < l.Music.Count; i++)
             {
-                var musicName = musicType + "." + enums[i];
+                var musicName = musicTypeName + "." + enums[i];
                 long key = ComputeEnumHash(enumType, i);
                 newLib.MusicKeys[i] = key;
                 audioFileLookup.Add(musicName, l.Music[i]);
@@ -931,6 +931,20 @@ namespace JSAM
         private static int GetEnumUnderlyingValue<T>(T e) where T : Enum
         {
             return unchecked(UnsafeUtility.As<T, int>(ref e));
+        }
+        
+        private Type FindEnumType(string soundType)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var type = assembly.GetType(soundType);
+                if (type != null && type.IsEnum)
+                {
+                    return type;
+                }
+            }
+            
+            throw new InvalidOperationException($"Enum type '{soundType}' was not found in loaded assemblies.");
         }
     }
 }

--- a/Runtime/Scripts/BaseAudioChannelHelper.cs
+++ b/Runtime/Scripts/BaseAudioChannelHelper.cs
@@ -275,12 +275,24 @@ namespace JSAM
 
             if (JSAMSettings.Settings.Spatialize && audioFile.spatialize)
             {
+                if (JSAMSettings.Settings.globalRolloffCurveOverride)
+                {
+                    AudioSource.rolloffMode = AudioRolloffMode.Custom;
+                    AudioSource.SetCustomCurve(AudioSourceCurveType.CustomRolloff, JSAMSettings.Settings.rolloffCurveOverride);
+                }
+                else
+                {
+                    AudioSource.rolloffMode = AudioRolloffMode.Logarithmic;
+                }
+                
                 AudioSource.spatialBlend = 1;
                 if (audioFile.maxDistance != 0)
                 {
                     AudioSource.maxDistance = audioFile.maxDistance;
                 }
                 else AudioSource.maxDistance = JSAMSettings.Settings.DefaultSoundMaxDistance;
+                
+                AudioSource.spread = JSAMSettings.Settings.DefaultSpread;
             }
             else
             {

--- a/Runtime/Scripts/JSAMSettings.cs
+++ b/Runtime/Scripts/JSAMSettings.cs
@@ -31,6 +31,11 @@ namespace JSAM
         [SerializeField] float defaultSoundMaxDistance = 7;
         public float DefaultSoundMaxDistance => defaultSoundMaxDistance;
 
+        [Tooltip("Spread for 3D spatialized audio")]
+        [SerializeField] float defaultSpread = 0f;
+        
+        public float DefaultSpread => defaultSpread;
+        
         [Tooltip("Affects how AudioClip lists are displayed in FileObject inspectors. " +
             "Toggle this option if you're experiencing issues manipulating Audio Clips in the inspector")]
         [SerializeField] bool useBuiltInAudioListRenderer = 
@@ -161,7 +166,12 @@ namespace JSAM
         [SerializeField] string voiceMutedKey = "JSAM_VOICE_MUTE";
         public string VoiceVolumeKey => voiceVolumeKey;
         public string VoiceMutedKey => voiceMutedKey;
-
+        
+        [SerializeField]
+        public bool globalRolloffCurveOverride = false;
+        [SerializeField]
+        public AnimationCurve rolloffCurveOverride = new AnimationCurve(new Keyframe(0, 1), new Keyframe(1, 0));
+        
         [Tooltip("The font size used when rendering \"quick reference guides\" in JSAM editor windows")]
         [SerializeField] int quickReferenceFontSize = 10;
         public int QuickReferenceFontSize


### PR DESCRIPTION
Instead of loading the type from the default Assembly-CSharp, we now scan all assemblies and get the type from the first one we found valid.

This might be a cumbersome process, and a better solution would be to remember the assembly name during enum generation, or at least put the assembly name in a separate AudioLibrary field.

But I believe we don't load libraries very often, so we can afford it. At least now the package will work in that cases.